### PR TITLE
Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+env/
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+from swipl
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip --no-install-recommends
+
+COPY requirements.txt /tmp/
+RUN pip3 install -r /tmp/requirements.txt
+
+COPY . /app
+WORKDIR /app
+
+ENV PORT 8000
+
+CMD python3 server.py

--- a/battleship.py
+++ b/battleship.py
@@ -17,5 +17,10 @@ def grid_none_to_prologany(grid):
 
 
 def solve(ships, row_clues, col_clues, grid):
-    query = f'Rows={grid}, battleship({ships}, {row_clues}, {col_clues}, Rows)'
+    query = 'Rows={grid}, battleship({ships}, {row_clues}, {col_clues}, Rows)'.format(
+        ships=ships,
+        row_clues=row_clues,
+        col_clues=col_clues,
+        grid=grid,
+    )
     return prolog.query(query)

--- a/server.py
+++ b/server.py
@@ -1,15 +1,14 @@
 import http.server
 import json
+import os
+
 from battleship import PrologAny, solve
 
-PORT = 8000
+PORT = int(os.environ.get('PORT', 8000))
+os.chdir(os.path.join(os.path.dirname(__file__), 'frontend'))
 
 
 class CustomHandler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args, **kwargs):
-        kwargs['directory'] = 'frontend/'
-        super().__init__(*args, **kwargs)
-
     def do_POST(self):
         length = self.headers['content-length']
         data = self.rfile.read(int(length))

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ class CustomHandler(http.server.SimpleHTTPRequestHandler):
     def do_POST(self):
         length = self.headers['content-length']
         data = self.rfile.read(int(length))
-        data = json.loads(data)
+        data = json.loads(data.decode('utf-8'))
         ships = data['ships']
         row_clues = data['rowClues']
         col_clues = data['colClues']


### PR DESCRIPTION
Docker base images size comparison:
- `python:3.7` then install `swi-prolog` package: ~995.8 MB
- `python:3.7-slim` then install `swi-prolog` package: ~505.5 MB
- `swipl` then install `python3` and `python3-pip` packages: ~195.2 MB

The `swipl` image (currently is `swipl:8.20`) is based on Debian Stretch which its supported python version is 3.5, so we need to downgrade the support.